### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install
+  - composer self-update
+  - composer install
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,19 @@
 		}
 	],
 	"require": {
-		"brick/math": "0.5.*"
+		"brick/math": "^0.5"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~5.7"
+		"phpunit/phpunit": "^5.7|^6.5"
 	},
 	"autoload": {
 		"psr-4": {
 			"Base62\\": "src"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Base62\\Tests\\": "tests/"
 		}
 	},
 	"support": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<phpunit colors="true" syntaxCheck="false" stopOnFailure="true" bootstrap="tests/bootstrap.php">
-	<testsuite name="Base62 simple test">
-		<directory>./tests/</directory>
-	</testsuite>
+<phpunit colors="true" syntaxCheck="false" stopOnFailure="true" bootstrap="vendor/autoload.php">
+    <testsuite name="Base62 simple test">
+	    <directory>./tests/</directory>
+    </testsuite>
+	<filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Base62\Tests;
+
 use Base62\Base62;
 use PHPUnit\Framework\TestCase;
 
@@ -7,31 +9,89 @@ class Base62Test extends TestCase {
 
 	public function setUp() {}
 
-	public function testEncode() {
-		$this->assertEquals('0', Base62::encode(0));
-		$this->assertEquals('g7', Base62::encode(999));
-		$this->assertEquals('14', Base62::encode(66));
-		// asserts for errors
-		$this->assertFalse(Base62::encode(-12));
-		$this->assertFalse(Base62::encode('not a number'));
+	public function encodeDataProvider() {
+		return [
+			['0', 0],
+			['g7', 999],
+			['14', 66],
+		];
 	}
 
-	public function testEncodeBigInteger() {
-		$this->assertEquals('2lkCB1', Base62::encode("2147483647"));
-		$this->assertEquals('YYLs9kDZ', Base62::encode("214748364712343"));
+	/**
+	 * @dataProvider encodeDataProvider
+	 */
+	public function testEncode($expectedString, $number) {
+		$this->assertEquals($expectedString, Base62::encode($number));
 	}
 
-	public function testDecode() {
-		$this->assertEquals(999, Base62::decode('g7'));
-		$this->assertEquals(66, Base62::decode('14'));
-		// asserts for errors
-		$this->assertFalse(Base62::decode(123));
-		$this->assertFalse(Base62::decode(false));
-		$this->assertFalse(Base62::decode([]));
+	public function invalidEncodedValueDataProvider() {
+		return [
+			[-12],
+			['not a number'],
+		];
 	}
 
-	public function testDecodeBigInteger() {
-		$this->assertEquals('2147483647', Base62::decode('2lkCB1'));
-		$this->assertEquals('214748364712343', Base62::decode('YYLs9kDZ'));
+	/**
+	 * @dataProvider invalidEncodedValueDataProvider
+	 */
+	public function testEncodeWithInvalidValue($invalidValue) {
+		$this->assertFalse(Base62::encode($invalidValue));
+	}
+
+	public function encodeBigIntegerDataProvider() {
+		return [
+			['2lkCB1', '2147483647'],
+			['YYLs9kDZ', '214748364712343'],
+		];
+	}
+
+	/**
+	 * @dataProvider encodeBigIntegerDataProvider
+	 */
+	public function testEncodeBigInteger($expectedString, $decodedString) {
+		$this->assertEquals($expectedString, Base62::encode($decodedString));
+	}
+
+	public function decodeDataProvider() {
+		return [
+			[999, 'g7'],
+			[66, '14'],
+		];
+	}
+
+	/**
+	 * @dataProvider decodeDataProvider
+	 */
+	public function testDecode($expectedNumber, $encodedString) {
+		$this->assertEquals($expectedNumber, Base62::decode($encodedString));
+	}
+
+	public function invalidDecodedValueDataProvider() {
+		return [
+			[123],
+			[false],
+			[[]],
+		];
+	}
+
+	/**
+	 * @dataProvider invalidDecodedValueDataProvider
+	 */
+	public function testDecodeWithInvalidValue($invalidValue) {
+		$this->assertFalse(Base62::decode($invalidValue));
+	}
+
+	public function decodeBigIntegerDataProvider() {
+		return [
+			['2147483647', '2lkCB1'],
+			['214748364712343', 'YYLs9kDZ'],
+		];
+	}
+
+	/**
+	 * @dataProvider decodeBigIntegerDataProvider
+	 */
+	public function testDecodeBigInteger($expectedString, $encodedString) {
+		$this->assertEquals($expectedString, Base62::decode($encodedString));
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ .'/../vendor/autoload.php';


### PR DESCRIPTION
# Changed log

- Set the current Travis setting in ```.travis.yml```.
- Set the multiple PHPUnit version to support the different PHP versions.
- Use the ```DataProvider``` to let the tests readability.
- Add the test namespace in ```autoload-dev``` setting in ```composer.json```.
- Remove the ```bootstrap.php``` file because it can set the ```vendor/autoload.php``` file directly in ```phpunit.xml``` file.