### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: true
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Base62 encoder and decorder also for big numbers. Useful to short database numer
 
 ## requirements
 
-* requires PHP >= 7.0.0 or higher
+* requires PHP >= 7.1.0 or higher
 * Composer
 * GMP (preferred) or BCMath extensions enabled.
 

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
 		}
 	],
 	"require": {
-		"php": ">=7.0.0"
+		"php": ">=7.1.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~6.0",
+		"phpunit/phpunit": "^7.0",
 		"squizlabs/php_codesniffer": "3.*",
 		"orchestra/testbench": "^3.5"
 	},
@@ -45,7 +45,8 @@
         }
     },
 	"suggest": {
-        "ext-gmp": "This extension enables faster big integer encoding and decoding."
+        "ext-gmp": "This extension enables faster big integer encoding and decoding.",
+        "ext-bcmath": "This extension enables arbitrary precision calculation encoding and decoding."
     },
 	"support": {
 		"issues": "https://github.com/SiroDiaz/Base62/issues",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,6 @@
 		convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
-		syntaxCheck="false"
 		stopOnFailure="true"
 		bootstrap="vendor/autoload.php">
 	<testsuite name="Base62 simple test">

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -10,7 +10,7 @@ class Base62Test extends TestCase
 {
     private $base62;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->base62 = new Base62('basic');
@@ -70,7 +70,7 @@ class Base62Test extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->assertNotEquals($expectedString, $this->base62->encode($decodedString));
     }
-    
+
     /**
      *
      * @dataProvider decodeDataProvider

--- a/tests/BcmathEncoderTest.php
+++ b/tests/BcmathEncoderTest.php
@@ -3,7 +3,6 @@
 namespace Base62\Tests;
 
 use Base62\Base62;
-use Base62\Drivers\BcmathEncoder;
 use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;
 
@@ -11,7 +10,7 @@ class BcmathEncoderTest extends TestCase
 {
     private $base62;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->base62 = new Base62('bcmath');
@@ -68,7 +67,7 @@ class BcmathEncoderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->base62->encode('12asd');
     }
-    
+
     /**
      *
      * @dataProvider encodeBigIntegerDataProvider
@@ -76,7 +75,7 @@ class BcmathEncoderTest extends TestCase
     public function testEncodeBigInteger($expectedString, $number) {
         $this->assertEquals($expectedString, $this->base62->encode($number));
     }
-    
+
     /**
      *
      * @dataProvider encodeBigIntegerDataProvider

--- a/tests/GmpEncoderTest.php
+++ b/tests/GmpEncoderTest.php
@@ -3,7 +3,6 @@
 namespace Base62\Tests;
 
 use Base62\Base62;
-use Base62\Drivers\GmpEncoder;
 use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;
 
@@ -11,7 +10,7 @@ class GmpEncoderTest extends TestCase
 {
     private $base62;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->base62 = new Base62('gmp');
@@ -67,7 +66,7 @@ class GmpEncoderTest extends TestCase
     public function testEncodeBigInteger($expectedString, $number) {
         $this->assertEquals($expectedString, $this->base62->encode($number));
     }
-    
+
     public function testDecode()
     {
         $this->assertEquals('999', $this->base62->decode('G7'));


### PR DESCRIPTION
# Changed log

- It seems that this package requires `php-7.1` version at least, and modify `php-7.1` on `README`.
- Adding the `bcmath` extension inside `suggest` block on `composer.json` file.
- Removing unused white spaces.
- Removing `syntaxcheck` attribute because it's invalid for `PHPUnit 7.x` version.
- Removing some declared namespace with `use` because they're not used.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/7.5/assertions.html#fixtures), it should be `protected function setUp(): void` and `protected function tearDown(): void` methods.